### PR TITLE
Update bluetooth-udev: move quotes into regex

### DIFF
--- a/install-bluetooth.sh
+++ b/install-bluetooth.sh
@@ -175,8 +175,7 @@ echo 'ACTION=="add", KERNEL=="hci0", RUN+="/bin/systemctl start bluealsa-aplay.s
 # Bluetooth udev script
 cat <<'EOF' > /opt/local/bin/bluetooth-udev
 #!/bin/bash
-name=$(sed 's/\"//g' <<< $NAME)
-if [[ ! $name =~ ^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$ ]]; then exit 0; fi
+if [[ ! $NAME =~ ^\"([0-9A-F]{2}[:-]){5}([0-9A-F]{2})\"$ ]]; then exit 0; fi
 
 action=$(expr "$ACTION" : "\([a-zA-Z]\+\).*")
 


### PR DESCRIPTION
The line: name=$(sed 's/\"//g' <<< $NAME) causes:
"cannot create temp file for here-document: Read-only"
Errors for me on recent raspbian.

We can fix this by putting the quotes into the regex checking for mac addresses.