### PR TITLE
Fix the path to hciconfig

### DIFF
--- a/install-bluetooth.sh
+++ b/install-bluetooth.sh
@@ -145,8 +145,8 @@ WantedBy=multi-user.target
 
 [Service]
 Type=simple
-ExecStartPre=/usr/bin/hciconfig hci0 piscan
-ExecStartPre=/usr/bin/hciconfig hci0 sspmode 1
+ExecStartPre=/bin/hciconfig hci0 piscan
+ExecStartPre=/bin/hciconfig hci0 sspmode 1
 ExecStart=/usr/local/bin/bluetooth-agent
 EOF
 systemctl enable bluetooth-agent.service


### PR DESCRIPTION
hciconfig is at `/bin/hciconfig` in buster, not `/usr/bin/hciconfig`

Resolves #23 