### PR TITLE
Fix systemd bluetooth-agent startup order

### DIFF
--- a/install-bluetooth.sh
+++ b/install-bluetooth.sh
@@ -138,10 +138,10 @@ cat <<'EOF' > /etc/systemd/system/bluetooth-agent.service
 [Unit]
 Description=Bluetooth Agent
 Requires=bluetooth.service
-After=bluetooth.target bluetooth.service
+After=bluetooth.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=bluetooth.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
On boot systemd complains about failing to start the bluetooth agent because the bluetooth.service is not yet started:

`hciconfig[308]: Can't get device info: No such device`

Setup: Raspberry Pi 3B with fresh and updated Buster Lite