### PR TITLE
change Shairport defaults with Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,21 @@ Sets up Bluetooth, adds a simple agent that accepts every connection, and enable
 
 ### AirPlay
 
-Installs [Shairport Sync](https://github.com/mikebrady/shairport-sync) AirPlay Audio Receiver.
+Installs [Shairport Sync](https://github.com/mikebrady/shairport-sync) AirPlay Audio Receiver. 
+
+You may override some of the default settings in the script using environment variables. 
+You could pass them directly to the script, 
+for instance if you want a different version:
+`sudo SHAIRPORT_VERSION=3.3.5 ./install.sh`
+
+Here is another example, exporting them before running the individual script to also compile using a different audio back-end:
+
+```
+export SHAIRPORT_VERSION=3.3.5
+export SHAIRPORT_CONFIGURE="--with-stdout --with-metadata --with-avahi --with-ssl=openssl --with-soxr"
+sudo ./install-shairport.sh
+```
+
 
 ### Spotify Connect
 

--- a/install-shairport.sh
+++ b/install-shairport.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
-SHAIRPORT_VERSION=3.3.1
+# these are defaults, but can be overridden by setting them before running
+: "${SHAIRPORT_VERSION:=3.3.1}"
+: "${SHAIRPORT_SYSCONFDIR:=/etc}"
+: "${SHAIRPORT_CONFIGURE:=--with-alsa --with-avahi --with-ssl=openssl --with-soxr}"
 
 echo -n "Do you want to install Shairport Sync AirPlay Audio Receiver (shairport-sync v${SHAIRPORT_VERSION})? [y/N] "
 read REPLY
@@ -13,7 +16,8 @@ tar xzf shairport_sync-v${SHAIRPORT_VERSION}.tar.gz
 rm shairport_sync-v${SHAIRPORT_VERSION}.tar.gz
 cd shairport-sync-${SHAIRPORT_VERSION}
 autoreconf -fi
-./configure --sysconfdir=/etc --with-alsa --with-avahi --with-ssl=openssl --with-systemd --with-soxr
+# left two options included as the script below determines them
+./configure --sysconfdir="${SHAIRPORT_SYSCONFDIR}" --with-systemd "${SHAIRPORT_CONFIGURE}"
 make
 make install
 cd ..
@@ -24,7 +28,7 @@ usermod -a -G gpio shairport-sync
 PRETTY_HOSTNAME=$(hostnamectl status --pretty)
 PRETTY_HOSTNAME=${PRETTY_HOSTNAME:-$(hostname)}
 
-cat <<EOF > /etc/shairport-sync.conf
+cat <<EOF > "${SHAIRPORT_SYSCONFDIR}/shairport-sync.conf"
 general = {
   name = "${PRETTY_HOSTNAME}";
 }

--- a/install-shairport.sh
+++ b/install-shairport.sh
@@ -17,7 +17,7 @@ rm shairport_sync-v${SHAIRPORT_VERSION}.tar.gz
 cd shairport-sync-${SHAIRPORT_VERSION}
 autoreconf -fi
 # left two options included as the script below determines them
-./configure --sysconfdir="${SHAIRPORT_SYSCONFDIR}" --with-systemd "${SHAIRPORT_CONFIGURE}"
+./configure --sysconfdir="${SHAIRPORT_SYSCONFDIR}" --with-systemd ${SHAIRPORT_CONFIGURE}
 make
 make install
 cd ..


### PR DESCRIPTION
Hi @nicokaiser - fantastic project - I have been looking for a solution to have these sound sources for ages, and you make it sooooo easy - many thanks!

Rather than hack my own fork _just_ for my own needs, I thought I would change the Shairport script a little to make it a) more variable driven and b) have defaults that can be overridden.

If a user takes this new script and uses it in the old way, it works just as before. However it allows them to change the behaviour just a little, to tweak it for their own needs. Have a look at the ReadMe to see how. I hope you agree that I have tried to keep the script as simple as possible, with just a list of what can be overriden at the top, and the defaults if the user specifies nothing. 

I welcome your comments
Thanks, Art