### PR TITLE
removing call for non-existing shell script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,6 @@ sudo ./install-shairport.sh
 sudo ./install-spotify.sh
 sudo ./install-upnp.sh
 sudo ./install-snapcast-client.sh
-sudo ./install-startup-sound.sh
 sudo ./install-pivumeter.sh
 sudo ./enable-hifiberry.sh
 sudo ./enable-read-only.sh


### PR DESCRIPTION
I got this error after running install.sh

> sudo: ./install-startup-sound.sh: command not found