### PR TITLE
use --mixer-linear-volume

### DIFF
--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -16,5 +16,5 @@ PRETTY_HOSTNAME=${PRETTY_HOSTNAME:-$(hostname)}
 cat <<EOF > /etc/default/raspotify
 DEVICE_NAME="${PRETTY_HOSTNAME}"
 BITRATE="320"
-VOLUME_ARGS="--linear-volume --initial-volume=100"
+VOLUME_ARGS="--mixer-linear-volume --initial-volume=100"
 EOF


### PR DESCRIPTION
First of all, thank you for an amazing install script. I'm effortlessly enjoying my music again :-)

There was one small hurdle: The raspotify service failed to start after reboot.

`--linear-volume` has apparently changed to `--mixer-linear-volume`

 Journalctl said:

```
Dec 31 14:38:58 rasputin systemd[1]: Starting Raspotify...
-- Subject: A start job for unit raspotify.service has begun execution
-- Defined-By: systemd
-- Support: https://www.debian.org/support
--
-- A start job for unit raspotify.service has begun execution.
--
-- The job identifier is 3795.
Dec 31 14:38:58 rasputin systemd[1]: Started Raspotify.
-- Subject: A start job for unit raspotify.service has finished successfully
-- Defined-By: systemd
-- Support: https://www.debian.org/support
--
-- A start job for unit raspotify.service has finished successfully.
--
-- The job identifier is 3795.
Dec 31 14:38:58 rasputin librespot[1854]: error: Unrecognized option: 'linear-volume'
Dec 31 14:38:58 rasputin librespot[1854]: Usage: /usr/bin/librespot [options]
Dec 31 14:38:58 rasputin librespot[1854]: Options:
Dec 31 14:38:58 rasputin librespot[1854]:     -c, --cache CACHE   Path to a directory where files will be cached.
Dec 31 14:38:58 rasputin librespot[1854]:         --disable-audio-cache
Dec 31 14:38:58 rasputin librespot[1854]:                         Disable caching of the audio data.
Dec 31 14:38:58 rasputin librespot[1854]:     -n, --name NAME     Device name
Dec 31 14:38:58 rasputin librespot[1854]:         --device-type DEVICE_TYPE
Dec 31 14:38:58 rasputin librespot[1854]:                         Displayed device type
Dec 31 14:38:58 rasputin librespot[1854]:     -b, --bitrate BITRATE
Dec 31 14:38:58 rasputin librespot[1854]:                         Bitrate (96, 160 or 320). Defaults to 160
Dec 31 14:38:58 rasputin librespot[1854]:         --onevent PROGRAM
Dec 31 14:38:58 rasputin librespot[1854]:                         Run PROGRAM when playback is about to begin.
Dec 31 14:38:58 rasputin librespot[1854]:         --emit-sink-events
Dec 31 14:38:58 rasputin librespot[1854]:                         Run program set by --onevent before sink is opened and
Dec 31 14:38:58 rasputin librespot[1854]:                         after it is closed.
Dec 31 14:38:58 rasputin librespot[1854]:     -v, --verbose       Enable verbose output
Dec 31 14:38:58 rasputin librespot[1854]:     -u, --username USERNAME
Dec 31 14:38:58 rasputin librespot[1854]:                         Username to sign in with
Dec 31 14:38:58 rasputin librespot[1854]:     -p, --password PASSWORD
Dec 31 14:38:58 rasputin librespot[1854]:                         Password
Dec 31 14:38:58 rasputin librespot[1854]:         --proxy PROXY   HTTP proxy to use when connecting
Dec 31 14:38:58 rasputin librespot[1854]:         --ap-port AP_PORT
Dec 31 14:38:58 rasputin librespot[1854]:                         Connect to AP with specified port. If no AP with that
Dec 31 14:38:58 rasputin librespot[1854]:                         port are present fallback AP will be used. Available
Dec 31 14:38:58 rasputin librespot[1854]:                         ports are usually 80, 443 and 4070
Dec 31 14:38:58 rasputin librespot[1854]:         --disable-discovery
Dec 31 14:38:58 rasputin librespot[1854]:                         Disable discovery mode
Dec 31 14:38:58 rasputin librespot[1854]:         --backend BACKEND
Dec 31 14:38:58 rasputin librespot[1854]:                         Audio backend to use. Use '?' to list options
Dec 31 14:38:58 rasputin librespot[1854]:         --device DEVICE Audio device to use. Use '?' to list options if using
Dec 31 14:38:58 rasputin librespot[1854]:                         portaudio or alsa
Dec 31 14:38:58 rasputin librespot[1854]:         --mixer MIXER   Mixer to use (alsa or softvol)
Dec 31 14:38:58 rasputin librespot[1854]:     -m, --mixer-name MIXER_NAME
Dec 31 14:38:58 rasputin librespot[1854]:                         Alsa mixer name, e.g "PCM" or "Master". Defaults to
Dec 31 14:38:58 rasputin librespot[1854]:                         'PCM'
Dec 31 14:38:58 rasputin librespot[1854]:         --mixer-card MIXER_CARD
Dec 31 14:38:58 rasputin librespot[1854]:                         Alsa mixer card, e.g "hw:0" or similar from `aplay
Dec 31 14:38:58 rasputin librespot[1854]:                         -l`. Defaults to 'default'
Dec 31 14:38:58 rasputin librespot[1854]:         --mixer-index MIXER_INDEX
Dec 31 14:38:58 rasputin librespot[1854]:                         Alsa mixer index, Index of the cards mixer. Defaults
Dec 31 14:38:58 rasputin librespot[1854]:                         to 0
Dec 31 14:38:58 rasputin librespot[1854]:         --mixer-linear-volume
Dec 31 14:38:59 rasputin librespot[1854]:                         Disable alsa's mapped volume scale (cubic). Default
Dec 31 14:38:59 rasputin librespot[1854]:                         false
Dec 31 14:38:59 rasputin librespot[1854]:         --initial-volume VOLUME
Dec 31 14:38:59 rasputin librespot[1854]:                         Initial volume in %, once connected (must be from 0 to
Dec 31 14:38:59 rasputin librespot[1854]:                         100)
Dec 31 14:38:59 rasputin librespot[1854]:         --zeroconf-port ZEROCONF_PORT
Dec 31 14:38:59 rasputin librespot[1854]:                         The port the internal server advertised over zeroconf
Dec 31 14:38:59 rasputin librespot[1854]:                         uses.
Dec 31 14:38:59 rasputin librespot[1854]:         --enable-volume-normalisation
Dec 31 14:38:59 rasputin librespot[1854]:                         Play all tracks at the same volume
Dec 31 14:38:59 rasputin librespot[1854]:         --normalisation-pregain PREGAIN
Dec 31 14:38:59 rasputin librespot[1854]:                         Pregain (dB) applied by volume normalisation
Dec 31 14:38:59 rasputin librespot[1854]:         --volume-ctrl VOLUME_CTRL
Dec 31 14:38:59 rasputin librespot[1854]:                         Volume control type - [linear, log, fixed]. Default is
Dec 31 14:38:59 rasputin librespot[1854]:                         logarithmic
Dec 31 14:38:59 rasputin librespot[1854]:         --autoplay      autoplay similar songs when your music ends.
```