### PR TITLE
Set LD_LIBRARY_PATH in order for shairport-sync to find compiled version of libalac

### DIFF
--- a/install-shairport.sh
+++ b/install-shairport.sh
@@ -54,6 +54,7 @@ cat <<'EOF' > /etc/systemd/system/shairport-sync.service.d/override.conf
 [Service]
 # Avahi daemon needs some time until fully ready
 ExecStartPre=/bin/sleep 3
+Environment=LD_LIBRARY_PATH=/usr/local/lib
 EOF
 
 PRETTY_HOSTNAME=$(hostnamectl status --pretty)


### PR DESCRIPTION
Might also be solved by `configure`ing different `LDFLAGS` here: https://github.com/nicokaiser/rpi-audio-receiver/commit/e579b0e4d09b8b6e52119f37aa25218d9d722abb.

Your choice :)