### PR TITLE
Fix up for Raspotify

### DIFF
--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -8,22 +8,14 @@ read REPLY
 if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then exit 0; fi
 
 curl -sL https://dtcooper.github.io/raspotify/install.sh | sh
-usermod -a -G pulse-access raspotify
-
-PRETTY_HOSTNAME=$(hostnamectl status --pretty | tr ' ' '-')
-PRETTY_HOSTNAME=${PRETTY_HOSTNAME:-$(hostname)}
-
-cat <<EOF > /etc/default/raspotify
-DEVICE_NAME="${PRETTY_HOSTNAME}"
-DEVICE_TYPE="avr"
-BITRATE="320"
-VOLUME_ARGS="--initial-volume=100"
-EOF
 
 mkdir -p /etc/systemd/system/raspotify.service.d
 cat <<'EOF' > /etc/systemd/system/raspotify.service.d/override.conf
 [Unit]
 Wants=pulseaudio.service
+
+[Service]
+SupplementaryGroups=pulse-access
 EOF
 
-systemctl enable raspotify
+systemctl restart raspotify


### PR DESCRIPTION
As of Raspotify 0.31.4 a fair amount has changed.

* PRETTY_HOSTNAME is unnecessary. Raspotify's default device name is already "raspotify(HOSTNAME)". It has been for a long while now.

* The Raspotify config file has moved and changed formats. https://github.com/dtcooper/raspotify/wiki/Migration-from-older-versions-to-0.31.4-and-beyond

* Raspotify no longer creates a "raspotify" user, it instead relies on systemd's DynamicUser functionality.

* Not setting the initial volume allows Raspotify to remember the volume between starts.

* Don't edit the Raspotify config. It has sane defaults that the user can change if they so desire. This also has the benefit of not having to worry about keeping up with librespot options and flags.