### PR TITLE
Update install-spotify.sh

### DIFF
--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -8,7 +8,13 @@ read REPLY
 if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then exit 0; fi
 
 curl -sL https://dtcooper.github.io/raspotify/install.sh | sh
-usermod -a -G gpio raspotify
+
+mkdir -p /etc/systemd/system/raspotify.service.d
+cat <<'EOF' > /etc/systemd/system/raspotify.service.d/override.conf
+[Service]
+#Add raspotify to gpio group
+SupplementaryGroups=gpio
+EOF
 
 PRETTY_HOSTNAME=$(hostnamectl status --pretty | tr ' ' '-')
 PRETTY_HOSTNAME=${PRETTY_HOSTNAME:-$(hostname)}


### PR DESCRIPTION
raspotify service has switched to using systemd 'Dynamic User'. 
See: https://github.com/dtcooper/raspotify/commit/014457af689b56d3dfec06d429146080f9fb54c8#diff-2fb1f135f17c0c89ef4d5cef05eb46497a029b6c76ca4d1d00d70fc139a45009
This causes the 'usermod' command to exit with an error.  
usermod command removed and replaced.
New command creates a systemd override.conf to add the raspostify service user to the 'gpio' group with the 'SupplementaryGroups' setting.