### PR TITLE
fix: shairport-sync double free detected in tcache 2, update raspotify and pulse config

### DIFF
--- a/install-shairport.sh
+++ b/install-shairport.sh
@@ -18,12 +18,8 @@ cat <<'EOF' > /etc/systemd/system/shairport-sync.service.d/override.conf
 ExecStartPre=/bin/sleep 3
 EOF
 
-PRETTY_HOSTNAME=$(hostnamectl status --pretty)
-PRETTY_HOSTNAME=${PRETTY_HOSTNAME:-$(hostname)}
-
 cat <<EOF > "/etc/shairport-sync.conf"
 general = {
-  name = "${PRETTY_HOSTNAME}";
   output_backend = "pa";
 }
 

--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -8,22 +8,30 @@ read REPLY
 if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then exit 0; fi
 
 curl -sL https://dtcooper.github.io/raspotify/install.sh | sh
-usermod -a -G pulse-access raspotify
 
 PRETTY_HOSTNAME=$(hostnamectl status --pretty | tr ' ' '-')
 PRETTY_HOSTNAME=${PRETTY_HOSTNAME:-$(hostname)}
 
-cat <<EOF > /etc/default/raspotify
-DEVICE_NAME="${PRETTY_HOSTNAME}"
-DEVICE_TYPE="avr"
-BITRATE="320"
-VOLUME_ARGS="--initial-volume=100"
+cat <<EOF > /etc/raspotify/conf
+LIBRESPOT_QUIET=
+LIBRESPOT_AUTOPLAY=
+LIBRESPOT_DISABLE_AUDIO_CACHE=
+LIBRESPOT_DISABLE_CREDENTIAL_CACHE=
+LIBRESPOT_ENABLE_VOLUME_NORMALISATION=
+LIBRESPOT_NAME="${PRETTY_HOSTNAME}"
+LIBRESPOT_DEVICE_TYPE="avr"
+LIBRESPOT_BITRATE="320"
+LIBRESPOT_INITIAL_VOLUME="100"
 EOF
 
 mkdir -p /etc/systemd/system/raspotify.service.d
 cat <<'EOF' > /etc/systemd/system/raspotify.service.d/override.conf
 [Unit]
 Wants=pulseaudio.service
-EOF
 
-systemctl enable raspotify
+[Service]
+SupplementaryGroups=pulse-access
+EOF
+systemctl daemon-reload
+
+systemctl enable --now raspotify

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ cat <<'EOF' >> /etc/pulse/client.conf
 default-server = /run/pulse/native
 autospawn = no
 EOF
+sed -i '/^load-module module-native-protocol-unix$/s/$/ auth-cookie-enabled=0 auth-anonymous=1/' /etc/pulse/system.pa
 
 # PulseAudio system daemon
 cat <<'EOF' > /etc/systemd/system/pulseaudio.service
@@ -30,7 +31,7 @@ WantedBy=multi-user.target
 [Service]
 Type=notify
 PrivateTmp=true
-ExecStart=/usr/bin/pulseaudio --daemonize=no --system --disallow-exit --disable-shm --exit-idle-time=-1 --log-target=journal
+ExecStart=/usr/bin/pulseaudio --daemonize=no --system --disallow-exit --disable-shm --exit-idle-time=-1 --log-target=journal --realtime --no-cpu-limit
 Restart=on-failure
 EOF
 systemctl enable --now pulseaudio.service


### PR DESCRIPTION
Hey,

Quick fixes for the following bugs:
- shairport-sync fails to start with `free(): double free detected in tcache 2` when (pretty) name is set
- raspotify/librespot configuration option names/file location was outdated (this also causes the install script to fail on `usermod`)
- raspotify can't access pulse (`Denied access to client with invalid authentication data.`)

See raspotify wiki [Configuration](https://github.com/dtcooper/raspotify/wiki/Configuration) & [PulseAudio as a system service](https://github.com/dtcooper/raspotify/wiki/Raspotify-with-PulseAudio-as-a-system-service)

Thank you for the project btw, it's quite neat 😊