### PR TITLE
Immediately start bluetooth and raspotify after installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ KillSignal=SIGUSR1
 WantedBy=multi-user.target
 EOF
     sudo systemctl daemon-reload
-    sudo systemctl enable bt-agent@hci0.service
+    sudo systemctl enable --now bt-agent@hci0.service
 
     # Bluetooth udev script
     sudo tee /usr/local/bin/bluetooth-udev >/dev/null <<'EOF'
@@ -194,7 +194,7 @@ LIBRESPOT_INITIAL_VOLUME="100"
 EOF
 
     sudo systemctl daemon-reload
-    sudo systemctl enable raspotify
+    sudo systemctl enable --now raspotify
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
Just like with the Shairport services, use `systemctl enable --now` for the bluetooth agent and raspotify service to immediately start them after the installtion completed