### PR TITLE
Pi Zero Support, snapcast UPnP go-librespotify and automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ Devices like phones, tablets and computers can play audio via this receiver.
 ## Installation
 
 The installation script asks whether to install each component.
-
-    wget https://raw.githubusercontent.com/nicokaiser/rpi-audio-receiver/main/install.sh
-    bash install.sh
-
-or
     
     wget https://raw.githubusercontent.com/flammableliquids/rpi-audio-receiver/main/install.sh
     bash install.sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Lets you choose the hostname and the visible device name ("pretty hostname") whi
 
 Sets up Bluetooth, adds a simple agent that accepts every connection, and enables audio playback through ALSA. A udev script is installed that disables discoverability while connected.
 
+### UPnP
+
+Installs [gmrender-resurrect](http://github.com/hzeller/gmrender-resurrect)
+UPnP Renderer
+
 ### AirPlay 2
 
 Installs [Shairport Sync](https://github.com/mikebrady/shairport-sync) AirPlay 2 Audio Receiver.
@@ -128,11 +133,17 @@ sudo nmcli connection modify preconfigured wifi.powersave 2
 When an external audio device (HDMI, USB, I2S) is used, the internal audio can be disabled in `/boot/firmware/config.txt` (replace `hifiberry-dacplus` with the overlay which fits your installation):
 
 ```
-...
 dtoverlay=disable-bt
 dtparam=audio=off
+dtoverlay=pi3-disable-bt
+```
+```
 dtoverlay=vc4-kms-v3d,noaudio
-dtoverlay=hifiberry-dacplus
+dtoverlay=dwc2,dr_mode=host
+```
+#### Enable Raspberry Pi DigiAmp Plus
+```
+dtoverlay=rpi-digiampplus,auto_mute_amp
 ```
 
 ### Add Bluetooth devices
@@ -247,6 +258,7 @@ There are many forks and similar projects that are optimized for more specific r
 
 - [Shairport Sync: AirPlay 2 audio player](https://github.com/mikebrady/shairport-sync)
 - [Raspotify: A Spotify Connect client that mostly Just Works™](https://github.com/dtcooper/raspotify)
+- [gmrender-resurrect](http://github.com/hzeller/gmrender-resurrect)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ Disabling Wi-Fi power management might resolve some connection issues:
 sudo nmcli connection modify preconfigured wifi.powersave 2
 ```
 
+### Enabling Audio DAC Amp Hats:
+
+|IQaudio Card| /boot/firmware/config.txt|
+|---|---|
+| DAC+ | ```dtoverlay=iqaudio-dacplus ``` |
+| DAC PRO | ```dtoverlay=iqaudio-dacplus ``` |
+| DigiAMP+ |  ```dtoverlay=iqaudio-dacplus,unmute_amp ``` or ``` dtoverlay=iqaudio-dacplus,auto_mute_amp ``` |
+| Codec Zero |```dtoverlay=iqaudio-codec ```|
+| |```dtoverlay=rpi-codeczero ```|
+| |```dtoverlay=rpi-dacplus ```|
+| |```dtoverlay=rpi-dacpro ```|
+| |```dtoverlay=rpi-digiampplus ```|
+
 ### Disable internal Bluetooth and Audio
 
 When an external audio device (HDMI, USB, I2S) is used, the internal audio can be disabled in `/boot/firmware/config.txt` (replace `hifiberry-dacplus` with the overlay which fits your installation):

--- a/config.txt
+++ b/config.txt
@@ -1,0 +1,56 @@
+# For more options and information see
+# http://rptl.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Enable audio (loads snd_bcm2835)
+# Disable audio that isn't helpful
+dtoverlay=disable-bt
+dtparam=audio=off
+dtoverlay=vc4-kms-v3d,noaudio
+dtoverlay=rpi-digiampplus,auto_mute_amp
+dtparam=krnbt
+
+# Additional overlays and parameters are documented
+# /boot/firmware/overlays/README
+
+# Automatically load overlays for detected cameras
+#camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+#display_auto_detect=1
+
+# Automatically load initramfs files, if found
+auto_initramfs=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Don't have the firmware create an initial video= setting in cmdline.txt.
+# Use the kernel's default instead.
+disable_fw_kms_setup=1
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+# Run as fast as firmware / board allows
+arm_boost=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[cm5]
+dtoverlay=dwc2,dr_mode=host
+
+[all]

--- a/install.sh
+++ b/install.sh
@@ -95,6 +95,8 @@ function askQuestion() {
   echo "$response"
 }
 
+#### To do, find the raspbian equivalent of netselect-apt
+#### netselect-apt doesn't seem to work on rpi os
 #     # netselect on rpi doesn't seem to actually change /etc/apt/sources.list
 #     # commenting out until i figure out why
 # apt_update_netselect(){
@@ -113,7 +115,7 @@ function update_latest(){
 }
 
 function verify_os() {
-    MSG="Unsupported OS: Raspberry Pi OS 12 (bookworm) is required."
+    MSG="Unsupported OS: Minimum Raspberry Pi OS 12 (bookworm) is required."
 
     if [ ! -f /etc/os-release ]; then
         log_red $MSG
@@ -123,8 +125,8 @@ function verify_os() {
 
     . /etc/os-release
 
-    if [ "$ID" != "debian" ] && [ "$ID" != "raspbian" ] || [ "$VERSION_ID" != "12" ]; then
-        log_red $MSG
+    if { [ "$ID" != "debian" ] && [ "$ID" != "raspbian" ]; } || [ "$VERSION_ID" -lt 12 ]; then
+        log_red "$MSG"
         banner
         exit 1
     fi
@@ -133,18 +135,19 @@ function verify_os() {
 function verify_raspberryZero(){
     MODEL=$(grep Model /proc/cpuinfo | awk -F: '{ gsub(/^ +| +$/, "", $2) ;print $2}')
     if [[ "$MODEL" == *" Zero "* ]]; then
-      log_yellow "dtCooper's version does not support Raspberry Pi Zero at this stage."
-      # echo "GO"
+      log_blue "dtCooper's version does not support Raspberry Pi Zero at this stage."
       return 0
     else
-      log_yellow "Device detected as ${MODEL}"
-      # echo "NO"
+      log_blue "Device detected as ${MODEL}"
       return 1
     fi
 }
 
 function set_hostname() {
     if [[ -z $changeHostname ]]; then
+      REPLY=$(askQuestion "Do you want to Change Hostname [y/N] " )
+      if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then return; fi
+    fi
       if ! $changeHostname ; then return; fi
 
       heading "Device Name Settings"
@@ -424,7 +427,7 @@ device_type: speaker
 bitrate: 320
 EOF
 
-        log_yellow "OS Detected as ${ARCH} will download the related GO client"
+        log_blue "OS Detected as ${ARCH} will download the related GO client"
         sudo apt-get install -y libogg-dev libvorbis-dev libasound2-dev
         if sudo systemctl is-active go-librespot-daemon.service; then
             sudo systemctl stop go-librespot-daemon.service
@@ -507,7 +510,7 @@ while getopts "nbsruc" opt; do
   esac
 done
 
-if (( $OPTIND == 1 )); then
+if [ $OPTIND == 1 ]; then
   echo "Default installation options"
   changeHostname=""
   bluetoothInstall=""

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,8 @@ function log_blue() {
 }
 function log_red() {
   local text="$1"
+  printf "${RED} ${text}${NORMAL}\r\n"
+}
 
 function banner(){
   # Get the terminal width

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ verify_os() {
 
     . /etc/os-release
 
-    if [ "$ID" != "debian" && "$ID" != "raspbian" ] || [ "$VERSION_ID" != "12" ]; then
+    if [ "$ID" != "debian" ] && [ "$ID" != "raspbian" ] || [ "$VERSION_ID" != "12" ]; then
         echo $MSG
         exit 1
     fi


### PR DESCRIPTION
Script uplift, including but not limited to:

- Bug fixes
- get-opts flags to allow for selective or automated execution
- snap-cast client
- UPnP client
- Support for Raspbian 32 bit in librespotify (go-librespotify)
- Support for Raspbian 13 (Trixie
- To Do: including netselect-apt for local mirror help
- better commenting.
- flag inclusion for debugging
- fixes to allow for functions to be installed independently (host-name variables)