### PR TITLE
Add Trixie compatibility fixes and installation checklist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Devices like phones, tablets and computers can play audio via this receiver.
 
 The installation script asks whether to install each component.
 
-    wget https://raw.githubusercontent.com/nicokaiser/rpi-audio-receiver/main/install.sh
+Download [`install.sh`](https://raw.githubusercontent.com/dave090679/rpi-audio-receiver/main/install.sh) from this fork, then run:
+
     bash install.sh
 
 **Note**: the installation process is not reversible, there is no uninstall. The script is meant to be run on a clean device that is not used for anything else.
@@ -43,6 +44,18 @@ Installs [Shairport Sync](https://github.com/mikebrady/shairport-sync) AirPlay 2
 ### Spotify Connect
 
 Installs [Raspotify](https://github.com/dtcooper/raspotify), an open source Spotify client for Raspberry Pi.
+
+### Fresh Trixie checklist
+
+For a fresh Raspberry Pi OS 13 (Trixie) setup, run through this checklist:
+
+1. Start from a clean Raspberry Pi OS 13 Lite image and complete first boot updates.
+2. Run the installer and enable Bluetooth/AirPlay/Spotify components you need.
+3. Answer `y` for the optional Trixie fixes.
+4. Answer `y` for HDMI audio disable when you use headphone jack, USB DAC, or I2S output.
+5. Reboot after installation to apply audio overlay and service changes.
+6. Verify Bluetooth state with `rfkill list` and pair a test device.
+7. Verify output device with `aplay -l` and run a short playback test.
 
 ## Additional steps
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ For a fresh Raspberry Pi OS 13 (Trixie) setup, run through this checklist:
 6. Verify Bluetooth state with `rfkill list` and pair a test device.
 7. Verify output device with `aplay -l` and run a short playback test.
 
+### Reviewer verification commands
+
+Run these commands on a freshly installed Trixie system after reboot:
+
+    # Core services should be active
+    systemctl --no-pager --full status bluetooth bt-agent@hci0 bluealsa bluealsa-aplay rfkill-unblock-bluetooth
+
+    # Bluetooth should not be soft/hard blocked
+    rfkill list
+
+    # Controller should be powered, pairable, and discoverable
+    bluetoothctl show
+
+    # noaudio overlay should be present if selected during install
+    grep -E '^dtoverlay=vc4-kms-v3d.*noaudio' /boot/firmware/config.txt
+
+    # Audio sink visibility
+    aplay -l
+
 ## Additional steps
 
 ### Enable HiFiBerry device

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ The installation script asks whether to install each component.
 
 **Note**: the installation process is not reversible, there is no uninstall. The script is meant to be run on a clean device that is not used for anything else.
 
+On Raspberry Pi OS 13 (Trixie), the installer can also apply optional compatibility fixes:
+
+- safe Bluetooth RFKill unblock (immediately and on every boot)
+- optional HDMI audio disable (`dtoverlay=vc4-kms-v3d,noaudio`) to force output to headphone/USB/I2S
+
 ### Basic setup
 
 Lets you choose the hostname and the visible device name ("pretty hostname") which is displayed as Bluetooth name, in AirPlay clients and in Spotify.
@@ -200,6 +205,26 @@ To enable pairing with a PIN code instead of Simple Secure Pairing mode, the fol
 - macOS allows pairing with devices with sspmode=0 (and a PIN configured on the Pi). When sspmode=1, macOS decides upon a PIN and either the Pi has a fixed PIN list (which does not match => connection refused), or requires keyboard input on the Pi (which is not desired for a headless device).
 
 So you need to try yourself if this works with your setup.
+
+### Bluetooth not discoverable
+
+If the Raspberry Pi is not visible as a Bluetooth device after installation, the Bluetooth radio may be soft-blocked. Unblock it with:
+
+```sh
+rfkill unblock 0
+```
+
+The unblocked state is saved persistently and survives reboots, so this only needs to be done once.
+
+### Force audio output to headphone jack
+
+If audio is routed to HDMI instead of the 3.5 mm headphone jack, add the `noaudio` parameter to the `vc4-kms-v3d` overlay in `/boot/firmware/config.txt`:
+
+```
+dtoverlay=vc4-kms-v3d,noaudio
+```
+
+This disables HDMI audio and forces output to the headphone jack.
 
 ## Limitations
 

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,7 @@ Requires=bluetooth.service
 After=bluetooth.service
 
 [Service]
+ExecStartPre=/usr/bin/bluetoothctl power on
 ExecStartPre=/usr/bin/bluetoothctl discoverable on
 ExecStartPre=/usr/bin/bluetoothctl pairable on
 ExecStart=/usr/bin/bt-agent --capability=NoInputNoOutput
@@ -77,6 +78,7 @@ KillSignal=SIGUSR1
 WantedBy=multi-user.target
 EOF
     sudo systemctl daemon-reload
+    sudo systemctl enable --now bluetooth
     sudo systemctl enable --now bt-agent@hci0.service
     sudo systemctl enable --now bluealsa
     sudo systemctl enable --now bluealsa-aplay

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-NQPTP_VERSION="1.2.4"
-SHAIRPORT_SYNC_VERSION="4.3.2"
+NQPTP_VERSION="1.2.6"
+SHAIRPORT_SYNC_VERSION="5.0.2"
 TMP_DIR=""
 
 cleanup() {
@@ -13,7 +13,7 @@ cleanup() {
 }
 
 verify_os() {
-    MSG="Unsupported OS: Raspberry Pi OS 12 (bookworm) is required."
+    MSG="Unsupported OS: Raspberry Pi OS 12 (bookworm) or 13 (trixie) is required."
 
     if [ ! -f /etc/os-release ]; then
         echo $MSG
@@ -22,7 +22,7 @@ verify_os() {
 
     . /etc/os-release
 
-    if [[ ("$ID" != "debian" && "$ID" != "raspbian") || "$VERSION_ID" != "12" ]]; then
+    if [[ ("$ID" != "debian" && "$ID" != "raspbian") || "$VERSION_ID" -lt 12 ]]; then
         echo $MSG
         exit 1
     fi
@@ -67,8 +67,7 @@ After=bluetooth.service
 
 [Service]
 ExecStartPre=/usr/bin/bluetoothctl discoverable on
-ExecStartPre=/bin/hciconfig %I piscan
-ExecStartPre=/bin/hciconfig %I sspmode 1
+ExecStartPre=/usr/bin/bluetoothctl pairable on
 ExecStart=/usr/bin/bt-agent --capability=NoInputNoOutput
 RestartSec=5
 Restart=always
@@ -78,7 +77,9 @@ KillSignal=SIGUSR1
 WantedBy=multi-user.target
 EOF
     sudo systemctl daemon-reload
-    sudo systemctl enable bt-agent@hci0.service
+    sudo systemctl enable --now bt-agent@hci0.service
+    sudo systemctl enable --now bluealsa
+    sudo systemctl enable --now bluealsa-aplay
 
     # Bluetooth udev script
     sudo tee /usr/local/bin/bluetooth-udev >/dev/null <<'EOF'
@@ -112,7 +113,8 @@ install_shairport() {
     if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then return; fi
 
     sudo apt update
-    sudo apt install -y --no-install-recommends wget unzip autoconf automake build-essential libtool git autoconf automake libpopt-dev libconfig-dev libasound2-dev avahi-daemon libavahi-client-dev libssl-dev libsoxr-dev libplist-dev libsodium-dev libavutil-dev libavcodec-dev libavformat-dev uuid-dev libgcrypt20-dev xxd
+    sudo apt install -y --no-install-recommends wget unzip autoconf automake build-essential libtool git libpopt-dev libconfig-dev libasound2-dev avahi-daemon libavahi-client-dev libssl-dev libsoxr-dev libplist-dev libplist-utils libsodium-dev libavutil-dev libavcodec-dev libavformat-dev uuid-dev libgcrypt-dev xxd
+    sudo apt install -y --no-install-recommends systemd-dev 2>/dev/null || true
 
     if [[ -z "$TMP_DIR" ]]; then
         TMP_DIR=$(mktemp -d)
@@ -148,7 +150,7 @@ install_shairport() {
     unzip shairport-sync-${SHAIRPORT_SYNC_VERSION}.zip
     cd shairport-sync-${SHAIRPORT_SYNC_VERSION}
     autoreconf -fi
-    ./configure --sysconfdir=/etc --with-alsa --with-soxr --with-avahi --with-ssl=openssl --with-systemd --with-airplay-2 --with-apple-alac
+    ./configure --sysconfdir=/etc --with-alsa --with-soxr --with-avahi --with-ssl=openssl --with-systemd-startup --with-airplay-2 --with-apple-alac
     make -j $(nproc)
     sudo make install
     cd ..
@@ -198,6 +200,50 @@ EOF
     sudo systemctl enable raspotify
 }
 
+install_trixie_fixes() {
+    read -p "Do you want to apply Trixie fixes (safe Bluetooth unblock and optional HDMI audio disable)? [y/N] " REPLY
+    if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then return; fi
+
+    # Ensure rfkill is available and unblock Bluetooth now.
+    sudo apt update
+    sudo apt install -y --no-install-recommends rfkill
+    sudo rfkill unblock bluetooth || true
+
+    # Keep Bluetooth unblocked across boots, before bluetooth.service starts.
+    sudo tee /etc/systemd/system/rfkill-unblock-bluetooth.service >/dev/null <<'EOF'
+[Unit]
+Description=Unblock Bluetooth RFKill
+DefaultDependencies=no
+After=local-fs.target
+Before=bluetooth.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/rfkill unblock bluetooth
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now rfkill-unblock-bluetooth.service
+
+    read -p "Disable HDMI audio and force output to headphone/USB/I2S (vc4-kms-v3d,noaudio)? [y/N] " REPLY
+    if [[ ! "$REPLY" =~ ^(yes|y|Y)$ ]]; then return; fi
+
+    if grep -Eq '^dtoverlay=vc4-kms-v3d.*noaudio' /boot/firmware/config.txt; then
+        echo "HDMI audio is already disabled in /boot/firmware/config.txt"
+        return
+    fi
+
+    if grep -Eq '^dtoverlay=vc4-kms-v3d' /boot/firmware/config.txt; then
+        sudo sed -i -E '/^dtoverlay=vc4-kms-v3d/ s/dtoverlay=vc4-kms-v3d/dtoverlay=vc4-kms-v3d,noaudio/' /boot/firmware/config.txt
+    else
+        echo 'dtoverlay=vc4-kms-v3d,noaudio' | sudo tee -a /boot/firmware/config.txt >/dev/null
+    fi
+
+    echo "Updated /boot/firmware/config.txt. Reboot required for HDMI audio changes."
+}
+
 trap cleanup EXIT
 
 echo "Raspberry Pi Audio Receiver"
@@ -207,3 +253,4 @@ set_hostname
 install_bluetooth
 install_shairport
 install_raspotify
+install_trixie_fixes


### PR DESCRIPTION
This PR updates the installer and documentation to make setup on Raspberry Pi OS 13 (Trixie) smoother and reproducible.

Summary of changes:
- accept Raspberry Pi OS 12+ in OS verification (Bookworm + Trixie)
- update NQPTP and Shairport Sync versions
- modernize Bluetooth setup (pairable via bluetoothctl, enable bluealsa services)
- add optional `install_trixie_fixes()` step:
  - safe Bluetooth RFKill unblock now and at boot via systemd service
  - optional HDMI audio disable (`dtoverlay=vc4-kms-v3d,noaudio`) for headphone/USB/I2S output
- update README:
  - switch installation download link to fork
  - add a fresh Trixie checklist
  - document Bluetooth discoverability and HDMI noaudio guidance

Goal:
A fresh Trixie installation should work without manual post-install fixes.